### PR TITLE
For development/testing:

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -123,6 +123,45 @@ jobs:
       run: |
         python setup.py bdist_msi
 
+    - name: Create Self-Signed Certificate (Development)
+      if: ${{ !inputs.use_production_signing }}
+      run: |
+        # Create a self-signed certificate for development
+        New-SelfSignedCertificate -Type Custom -Subject "CN=P2PP Development" -KeyUsage DigitalSignature `
+          -FriendlyName "P2PP Development Certificate" -CertStoreLocation "Cert:\CurrentUser\My" `
+          -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}false")
+        
+        # Export certificate info for signing
+        $cert = Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object {$_.FriendlyName -eq "P2PP Development Certificate"}
+        echo "SIGNING_CERT_THUMBPRINT=$($cert.Thumbprint)" >> $env:GITHUB_ENV
+      shell: pwsh
+
+    - name: Sign MSI (Development)
+      if: ${{ !inputs.use_production_signing }}
+      run: |
+        # Sign with self-signed certificate
+        $cert = Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object {$_.Thumbprint -eq $env:SIGNING_CERT_THUMBPRINT}
+        Set-AuthenticodeSignature -FilePath "dist\*.msi" -Certificate $cert -TimestampServer "http://timestamp.digicert.com"
+      shell: pwsh
+
+    - name: Sign MSI (Production)
+      if: ${{ inputs.use_production_signing }}
+      env:
+        WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+        WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+      run: |
+        # Decode and save the certificate
+        $certBytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE)
+        $certPath = "certificate.pfx"
+        [IO.File]::WriteAllBytes($certPath, $certBytes)
+        
+        # Sign the MSI
+        signtool sign /f $certPath /p $env:WINDOWS_CERTIFICATE_PASSWORD /tr http://timestamp.digicert.com /td sha256 /fd sha256 "dist\*.msi"
+        
+        # Clean up
+        Remove-Item $certPath
+      shell: pwsh
+
     - name: Upload to Release
       if: inputs.upload_to_release && startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/build-packages.yml
     with:
       upload_to_release: true
-      use_production_signing: ${{ secrets.APPLE_CERTIFICATE != '' }}
+      use_production_signing: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.WINDOWS_CERTIFICATE != '' }}


### PR DESCRIPTION
The self-signed certificate will be created automatically Users will get a warning but can still run the software The certificate will be different on each build (this is fine for testing) For production (when you're ready):
1. Purchase a code signing certificate from a provider like: DigiCert
Sectigo (formerly Comodo)
GlobalSign
2. Export the certificate as PFX/P12 file Add these secrets to your GitHub repository:
WINDOWS_CERTIFICATE: Base64 encoded PFX/P12 file
WINDOWS_CERTIFICATE_PASSWORD: Password for the certificate Until then, the self-signed certificate will work fine for development and testing. When you're ready to distribute more widely, you can decide whether to: Start with no signing (cheaper but more warnings)
Use self-signed (free but still warnings)
Get a standard certificate (moderate cost, fewer warnings) Get an EV certificate (expensive but best user experience) Most open source projects either:
Don't sign their Windows builds
Use standard certificates (not EV) as a middle ground Get sponsored by certificate providers (some offer free certificates to open source projects) You might want to start without signing for Windows and add it later when the project grows, as Windows users are more accustomed to unsigned applications than macOS users.