### PR TITLE
update version script to use vhspace/p2pp instead of tomvandeneede/p2pp

### DIFF
--- a/p2pp/checkversion.py
+++ b/p2pp/checkversion.py
@@ -9,7 +9,7 @@ __email__ = 'P2PP@pandora.be'
 
 import platform
 
-MASTER = "https://github.com/tomvandeneede/p2pp/raw/master/version.py"
+MASTER = "https://raw.githubusercontent.com/vhspace/p2pp/master/version.py"
 
 _p = platform.python_version().strip()
 python_version = _p[0]

--- a/version.py
+++ b/version.py
@@ -191,8 +191,8 @@ releaseinfo = {
 
 # general version info
 MajorVersion = 10
-MinorVersion = 0
-Build = 0
+MinorVersion = 1
+Build = 2
 
 Version = "{}.{:02}.{:02}".format(MajorVersion, MinorVersion, Build)
 


### PR DESCRIPTION
Also updated version so people will get a warning that there is a new version.

I updated the version based on the latest tagged version and upped the buildnumber. 
Or should it be 10.2.1? (aka new minor version, first build?)