### PR TITLE
address issue #30: relax backpass requirements to also allow Z moveme…

### DIFF
--- a/p2pp/mcf.py
+++ b/p2pp/mcf.py
@@ -403,9 +403,9 @@ def parse_gcode_first_pass():
                 else:
                     v.bed.position(code[gcode.X], code[gcode.Y])
 
-        # determine block separators by looking at the last full XY positioning move
-        if (code[gcode.MOVEMENT] & 3) == 3:
-            if (code[gcode.MOVEMENT] & 12) == 0:
+        # determine block separators by looking at the last full XY positioning move without extrusion
+        if (code[gcode.MOVEMENT] & 3) == 3: # XY
+            if (code[gcode.MOVEMENT] & 8) == 0: # no extrusion
                 backpass_line = len(v.parsed_gcode) - 1
 
             # add

--- a/version.py
+++ b/version.py
@@ -191,8 +191,8 @@ releaseinfo = {
 
 # general version info
 MajorVersion = 10
-MinorVersion = 1
-Build = 2
+MinorVersion = 2
+Build = 1
 
 Version = "{}.{:02}.{:02}".format(MajorVersion, MinorVersion, Build)
 


### PR DESCRIPTION
Attempt at fixing the issues where parts of the actual print are commented out by P2PP. Needs testing though. It seems to happen only when zhop is enabled (which is default in Orca)