### PR TITLE
Docs, badges, and GitHub Pages workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,9 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources
 
 # Update package list and install basic dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gpg \
     git \
     libegl1 \
     libgl1 \
@@ -44,6 +47,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxi-dev \
     libxkbcommon-dev \
     libxkbcommon-x11-dev \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,8 +5,13 @@ ENV QT_DEBUG_PLUGINS=1
 ENV PYTHONPATH=/workspace
 ENV QT_QPA_PLATFORM=xcb
 
+# The base devcontainer image can include a Yarn APT source without its GPG key
+# in some environments. Remove it to keep apt-get update reliable.
+RUN rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn.sources || true
+
 # Update package list and install basic dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
     libegl1 \
     libgl1 \
     libxcb-icccm4 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,13 @@
     "features": {
         "ghcr.io/devcontainers/features/desktop-lite:1": {}
     },
-    "forwardPorts": [6080],
+    "forwardPorts": [6080, 8000],
     "portsAttributes": {
         "6080": {
             "label": "desktop"
+        },
+        "8000": {
+            "label": "mkdocs"
         }
     },
     "customizations": {
@@ -20,5 +23,5 @@
             ]
         }
     },
-    "postCreateCommand": "pip install -r requirements.txt"
+    "postCreateCommand": "bash -lc \"(test -d .venv-mkdocs || python3 -m venv .venv-mkdocs) && . .venv-mkdocs/bin/activate && python -m pip install -U pip && python -m pip install -r docs/_p2pp/mkdocs-requirements.txt\""
 }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/_p2pp/mkdocs-requirements.txt
+
+      - name: Deploy docs to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mkdocs gh-deploy -f docs/_p2pp/mkdocs.yml --clean

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ build/**
 dist/**
 .vscode/settings.json
 docs/_p2pp/.cache/
+.cache/
 site/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # p2pp - **Palette2 Post Processing tool for PrusaSlicer/Slic3r PE**
 
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ballew@sublinear.net&lc=EU&item_name=Donation+to+P2PP+Developer&no_note=0&cn=&currency_code=USD&bn=PP-DonationsBF:btn_donateCC_LG.gif:NonHosted)
+[![Release](https://img.shields.io/github/v/release/vhspace/p2pp)](https://github.com/vhspace/p2pp/releases)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/vhspace/p2pp/pulls)
+[![Build](https://img.shields.io/github/actions/workflow/status/vhspace/p2pp/build.yml?branch=master&label=build)](https://github.com/vhspace/p2pp/actions/workflows/build.yml)
+[![Docs](https://img.shields.io/badge/docs-online-blue)](https://vhspace.github.io/p2pp/)
+[![Stars](https://img.shields.io/github/stars/vhspace/p2pp?style=social)](https://github.com/vhspace/p2pp/stargazers)
+[![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/gg6DeK9Qfs)
+
+[![Palette 2](https://img.shields.io/badge/Palette%202-supported-blueviolet)](https://github.com/vhspace/p2pp)
+[![Palette 3](https://img.shields.io/badge/Palette%203-supported-blueviolet)](https://github.com/vhspace/p2pp)
+[![Multi-color](https://img.shields.io/badge/multi--color-printing-ffcc00)](https://github.com/vhspace/p2pp)
+[![Multi-material](https://img.shields.io/badge/multi--material-post--processing-ffcc00)](https://github.com/vhspace/p2pp)
+[![PrusaSlicer](https://img.shields.io/badge/PrusaSlicer-supported-orange)](https://github.com/vhspace/p2pp)
+
 ## Getting strarted
 
 Have a look at the [P2PP Docs](https://vhspace.github.io/p2pp/) to get youstarted.
@@ -16,7 +30,13 @@ Kurt for making the instructional video n setting up and using p2pp.
 
 If you like this software and want to support its development you can make a small donation to support further development of P2PP.
 
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=t.vandeneede@pandora.be&lc=EU&item_name=Donation+to+P2PP+Developer&no_note=0&cn=&currency_code=EUR&bn=PP-DonationsBF:btn_donateCC_LG.gif:NonHosted)
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ballew@sublinear.net&lc=EU&item_name=Donation+to+P2PP+Developer&no_note=0&cn=&currency_code=USD&bn=PP-DonationsBF:btn_donateCC_LG.gif:NonHosted)
+
+P2PP is sponsored by [VHSpace](https://vhspace.org), a community created by [chatresearch.org](https://chatresearch.org), a Washington state non-profit organization.
+
+EIN: 83-1602344
+
+Donations may be tax-deductible in some jurisdictions. Please consult your tax advisor.
 
 
 

--- a/docs/_p2pp/mkdocs-requirements.txt
+++ b/docs/_p2pp/mkdocs-requirements.txt
@@ -1,6 +1,5 @@
 # Python virtualenv module requirements for mkdocs
 mkdocs>=1.6.1
 mkdocs-material>=9.7.1
-click==8.2.1
 mkdocs-git-committers-plugin-2>=1.6.1
-mkdocs-git-authors-plugin>=1.0.4
+mkdocs-git-authors-plugin>=0.10.0

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,7 +1,81 @@
 # Contributing
 
+Thanks for your interest in contributing to P2PP.
 
-TODO  
+If this is your first contribution, this page walks you through the process from code changes to review.
 
+## First contribution checklist
 
-When you've implemented a new feature, please document it in our docs. It wil help to maintain the project and help others to use your implemented feature.
+1. Fork this repository to your own GitHub account.
+2. Create a branch for your change.
+3. Implement your change in small, reviewable commits.
+4. Add tests:
+   - Include unit tests for changed behavior.
+   - Add an end-to-end (e2e) test when the change affects a full user workflow and an e2e test is practical.
+5. Update docs when behavior, configuration, or usage changes.
+6. Push your branch and open a Pull Request (PR).
+7. Ask for review and address feedback.
+
+Example branch setup:
+
+```sh
+git checkout -b yourname/short-change-description
+```
+
+## Testing expectations
+
+Before opening a PR:
+
+- Run the relevant unit tests and confirm they pass.
+- Add or update unit tests for bug fixes and new features.
+- If possible, include e2e coverage for user-facing flows impacted by your change.
+- Mention what you tested in the PR description (for example: "unit tests passed", "manual validation", "e2e added/skipped with reason").
+
+If you are not sure which tests to run, open the PR anyway and call that out explicitly so maintainers can guide you.
+
+## Opening a Pull Request
+
+When your branch is ready:
+
+1. Push your branch to your fork.
+2. Open a PR to `vhspace/p2pp:master`.
+3. In the PR description, include:
+   - What changed and why.
+   - Screenshots/logs for UI or output changes (if applicable).
+   - Test evidence (unit tests, e2e tests, or why e2e was not feasible).
+   - Any follow-up work or known limitations.
+4. Mark the PR ready for review.
+
+After review starts:
+
+- Respond to comments and push follow-up commits.
+- Keep discussion focused on behavior and correctness.
+- Re-run tests after substantial updates.
+
+## Documentation updates
+
+When you've implemented a new feature, please document it in our docs. This helps maintain the project and helps others use your feature.
+
+The documentation content is in `docs/`. MkDocs is configured via `docs/_p2pp/mkdocs.yml`.
+
+### Local preview
+
+```sh
+python3 -m venv .venv-mkdocs
+source .venv-mkdocs/bin/activate
+python -m pip install -r docs/_p2pp/mkdocs-requirements.txt
+mkdocs serve -f docs/_p2pp/mkdocs.yml
+```
+
+### Deploy to GitHub Pages
+
+Docs are automatically deployed to GitHub Pages from GitHub Actions when changes to docs are merged into `master`.
+
+If you need to deploy manually, MkDocs can still push the generated site to the `gh-pages` branch:
+
+```sh
+source .venv-mkdocs/bin/activate
+mkdocs gh-deploy -f docs/_p2pp/mkdocs.yml --clean
+```
+
+If deployment fails due to GitHub API rate limits in `git-committers` / `git-authors`, set `GITHUB_TOKEN=...` and retry.


### PR DESCRIPTION
## Summary
- Move MkDocs usage details into the docs site and expand contributing guidance for first-time contributors (PR + unit tests, e2e when feasible).
- Add GitHub Actions workflow to deploy MkDocs to `gh-pages` on pushes to `master` affecting `docs/`.
- Refresh README: badges (Donate first, Discord link, PRs welcome, 3D-printing related badges) and update donation/sponsorship details.
- Ignore top-level `.cache/` artifacts.
- Install `gh` in the devcontainer for easier PR workflows.

## Test plan
- [ ] Spot-check README links/badges render correctly.
- [ ] (Optional) Run `mkdocs build -f docs/_p2pp/mkdocs.yml` locally.
- [ ] Verify the `Deploy Docs` workflow runs on a docs-only change.
