### PR TITLE
check G0/G2/G3 for extrusion parameters

### DIFF
--- a/p2pp/gcode.py
+++ b/p2pp/gcode.py
@@ -81,7 +81,7 @@ def create_command(gcode_line, is_comment=False, userclass=0):
                     return create_command("M400", False, userclass)
 
             check = (param_coefficient & 31)
-            if check and return_value[COMMAND] == "G1":
+            if check and return_value[COMMAND] in ("G0", "G1", "G2", "G3"):
                 return_value[MOVEMENT] = check
                 if param_coefficient & 8:
                     if return_value[E] < 0:


### PR DESCRIPTION
Hey, 

Thanks for this fork! I've been able to get some very good results on a Prusa MK3.5S + Palette 3 Pro with a few modifications to the gcode parser.

Certain movements such as G2/G3 (arc) and G0 (rapid linear) may have extrusion commands which need to be converted between rel/abs. The issue manifests as the printer dumping a blob of filament at the start of the move and nothing during travel. This happens on my MK3.5S and Mini. I assume G0 was added for the 32-bit buddy boards and Prusa Slicer added support for "arc welding" in 2.7(?)

The PR adds support to detect `E` commands for these other movements.

Cheers
Josh