### PR TITLE
fix float truncation for mesh bed leveling

### DIFF
--- a/p2pp/gcode.py
+++ b/p2pp/gcode.py
@@ -130,7 +130,11 @@ def create_commandstring(gcode_tupple):
             else:
                 p = p + " S{}".format(float(gcode_tupple[S]))
         if gcode_tupple[P] is not None:
-            p = p + " P{}".format(int(gcode_tupple[P]))
+            tmpv = float(gcode_tupple[P])
+            if tmpv == int(tmpv):
+                p = p + " P{}".format(int(gcode_tupple[P]))
+            else:
+                p = p + " P{}".format(gcode_tupple[P])
         p = p + gcode_tupple[OTHER]
         if gcode_tupple[COMMENT] != "":
             p = p + " " + gcode_tupple[COMMENT]


### PR DESCRIPTION
Mesh bed leveling is typically a command like `G29 P3.x`. The interpreter does a float -> int conversion on the `P` parameter which converts P3.2 (interpolation) to P3 (basic) i.e. the command is copied, but it gets modified along the way. This results in poorer calibration offsets, like only a small part of the bed being level, while printing the same file directly (with a well dialled in z-height) looks fine.

This PR preserves float values if present, and otherwise keeps int (so P3 does not get turned into P3.0). See the behavior for `[S]` a few lines above which does this already; I copied that logic.